### PR TITLE
Add navigation, registration flow, and sign-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# lock file
+package-lock.json

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,6 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack />;
+}
+

--- a/app/auth/register.tsx
+++ b/app/auth/register.tsx
@@ -9,50 +9,42 @@ import {
   Alert,
 } from 'react-native';
 import { auth } from '@/firebase';
-import { signInWithEmailAndPassword } from 'firebase/auth';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
 
-// Simple email validator.  Returns true if the string appears to be a valid
-// email address.  This is not exhaustive but catches common mistakes.
-const isValidEmail = (value: string): boolean => {
-  return /\S+@\S+\.\S+/.test(value);
-};
+const isValidEmail = (value: string): boolean => /\S+@\S+\.\S+/.test(value);
 
-export default function LoginScreen() {
+export default function RegisterScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const handleLogin = async () => {
-    // Trim whitespace from inputs
+  const handleRegister = async () => {
     const trimmedEmail = email.trim();
     const trimmedPassword = password.trim();
+    const trimmedConfirm = confirm.trim();
 
-    // Basic validation before hitting the network
     if (!isValidEmail(trimmedEmail)) {
       Alert.alert('Invalid Email', 'Please enter a valid email address.');
       return;
     }
     if (trimmedPassword.length < 6) {
-      Alert.alert(
-        'Invalid Password',
-        'Password must be at least 6 characters long.',
-      );
+      Alert.alert('Invalid Password', 'Password must be at least 6 characters long.');
+      return;
+    }
+    if (trimmedPassword !== trimmedConfirm) {
+      Alert.alert('Password Mismatch', 'Passwords do not match.');
       return;
     }
 
     setLoading(true);
     try {
-      await signInWithEmailAndPassword(auth, trimmedEmail, trimmedPassword);
-      Alert.alert('Success', 'You are logged in!');
-      // Navigate to the share section after login
-      router.replace('/main/share');
+      await createUserWithEmailAndPassword(auth, trimmedEmail, trimmedPassword);
+      Alert.alert('Success', 'Account created!');
+      router.replace('/main/edit');
     } catch (error: any) {
-      // Provide a friendlier error message if possible
-      const message =
-        (error?.code === 'auth/wrong-password'
-          ? 'Incorrect email or password.'
-          : error?.message) || 'Unable to log in.';
-      Alert.alert('Login Error', message);
+      const message = error?.message || 'Unable to create account.';
+      Alert.alert('Registration Error', message);
     } finally {
       setLoading(false);
     }
@@ -60,7 +52,7 @@ export default function LoginScreen() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Login</Text>
+      <Text style={styles.title}>Register</Text>
       <TextInput
         style={styles.input}
         value={email}
@@ -76,14 +68,21 @@ export default function LoginScreen() {
         placeholder="Password"
         secureTextEntry
       />
+      <TextInput
+        style={styles.input}
+        value={confirm}
+        onChangeText={setConfirm}
+        placeholder="Confirm Password"
+        secureTextEntry
+      />
       <Button
-        title={loading ? 'Logging in…' : 'Login'}
-        onPress={handleLogin}
+        title={loading ? 'Creating…' : 'Create Account'}
+        onPress={handleRegister}
         disabled={loading}
       />
       <Button
-        title="Create Account"
-        onPress={() => router.replace('/auth/register')}
+        title="Back to Login"
+        onPress={() => router.replace('/auth/login')}
       />
     </View>
   );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/firebase';
+import { router } from 'expo-router';
+
+export default function Index() {
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        router.replace('/main/share');
+      } else {
+        router.replace('/auth/login');
+      }
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/main/share/index.tsx
+++ b/app/main/share/index.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from 'expo-router';
 import React from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
+import { signOut } from 'firebase/auth';
+import { auth } from '@/firebase';
 
 // Landing page for the share section.  Offers quick actions to view,
 // edit or preview a card.
@@ -20,6 +22,12 @@ export default function ShareIndexScreen() {
       <Button
         title="View Shared Card (Demo)"
         onPress={() => router.push('/main/share/123')}
+      />
+      <Button
+        title="Sign Out"
+        onPress={() =>
+          signOut(auth).then(() => router.replace('/auth/login'))
+        }
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- add root layout and index redirect based on Firebase auth state
- add user registration screen and link from login
- add sign-out button on share index screen and ignore lock file

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689019bfa58883309238237dc87b29a7