### PR TITLE
feat: add subscription paywall

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,11 @@
 import { Stack } from 'expo-router';
+import { SubscriptionProvider } from '@/providers/SubscriptionProvider';
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <SubscriptionProvider>
+      <Stack />
+    </SubscriptionProvider>
+  );
 }
 

--- a/app/main/analytics.tsx
+++ b/app/main/analytics.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { View, Text, Alert } from 'react-native';
+import { router } from 'expo-router';
+import { useSubscription } from '@/providers/SubscriptionProvider';
+
+export default function AnalyticsScreen() {
+  const { isPro, purchase } = useSubscription();
+
+  useEffect(() => {
+    if (!isPro) {
+      Alert.alert(
+        'Upgrade Required',
+        'Analytics are available on Pro or Team plans.',
+        [
+          { text: 'Cancel', style: 'cancel', onPress: () => router.back() },
+          { text: 'Upgrade', onPress: () => purchase() },
+        ]
+      );
+    }
+  }, [isPro]);
+
+  if (!isPro) {
+    return null;
+  }
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Analytics Feature</Text>
+    </View>
+  );
+}

--- a/app/main/crm.tsx
+++ b/app/main/crm.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { View, Text, Alert } from 'react-native';
+import { router } from 'expo-router';
+import { useSubscription } from '@/providers/SubscriptionProvider';
+
+export default function CRMSyncScreen() {
+  const { isPro, purchase } = useSubscription();
+
+  useEffect(() => {
+    if (!isPro) {
+      Alert.alert(
+        'Upgrade Required',
+        'CRM sync is available on Pro or Team plans.',
+        [
+          { text: 'Cancel', style: 'cancel', onPress: () => router.back() },
+          { text: 'Upgrade', onPress: () => purchase() },
+        ]
+      );
+    }
+  }, [isPro]);
+
+  if (!isPro) {
+    return null;
+  }
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>CRM Sync Feature</Text>
+    </View>
+  );
+}

--- a/app/main/notes.tsx
+++ b/app/main/notes.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { View, Text, Alert } from 'react-native';
+import { router } from 'expo-router';
+import { useSubscription } from '@/providers/SubscriptionProvider';
+
+export default function NotesScreen() {
+  const { isPro, purchase } = useSubscription();
+
+  useEffect(() => {
+    if (!isPro) {
+      Alert.alert(
+        'Upgrade Required',
+        'Notes are available on Pro or Team plans.',
+        [
+          { text: 'Cancel', style: 'cancel', onPress: () => router.back() },
+          { text: 'Upgrade', onPress: () => purchase() },
+        ]
+      );
+    }
+  }, [isPro]);
+
+  if (!isPro) {
+    return null;
+  }
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Notes Feature</Text>
+    </View>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.13.1",
     "react-native-svg": "15.11.2",
+    "react-native-purchases": "^7.19.1",
     "tailwind-variants": "^2.1.0",
     "tailwindcss": "^3.4.17"
   },

--- a/providers/SubscriptionProvider.tsx
+++ b/providers/SubscriptionProvider.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { configureRevenueCat, isProUser, purchaseSubscription } from '@/revenuecat';
+
+interface SubscriptionContextValue {
+  isPro: boolean;
+  refresh: () => Promise<void>;
+  purchase: () => Promise<void>;
+}
+
+const SubscriptionContext = createContext<SubscriptionContextValue>({
+  isPro: false,
+  refresh: async () => {},
+  purchase: async () => {},
+});
+
+export function SubscriptionProvider({ children }: { children: ReactNode }) {
+  const [isPro, setIsPro] = useState(false);
+
+  const refresh = async () => {
+    const pro = await isProUser();
+    setIsPro(pro);
+  };
+
+  useEffect(() => {
+    configureRevenueCat();
+    refresh();
+  }, []);
+
+  const purchase = async () => {
+    await purchaseSubscription();
+    refresh();
+  };
+
+  return (
+    <SubscriptionContext.Provider value={{ isPro, refresh, purchase }}>
+      {children}
+    </SubscriptionContext.Provider>
+  );
+}
+
+export function useSubscription() {
+  return useContext(SubscriptionContext);
+}

--- a/revenuecat.ts
+++ b/revenuecat.ts
@@ -1,0 +1,38 @@
+import Purchases from 'react-native-purchases';
+import { Platform } from 'react-native';
+
+const API_KEYS: Record<string, string> = {
+  ios: 'REVENUECAT_IOS_API_KEY',
+  android: 'REVENUECAT_ANDROID_API_KEY',
+};
+
+export function configureRevenueCat() {
+  const apiKey = API_KEYS[Platform.OS];
+  if (apiKey) {
+    Purchases.configure({ apiKey });
+  }
+}
+
+export async function isProUser(): Promise<boolean> {
+  try {
+    const info = await Purchases.getCustomerInfo();
+    return Boolean(
+      info.entitlements.active['pro'] || info.entitlements.active['team']
+    );
+  } catch (e) {
+    console.warn('RevenueCat check failed', e);
+    return false;
+  }
+}
+
+export async function purchaseSubscription() {
+  try {
+    const offerings = await Purchases.getOfferings();
+    const pkg = offerings.current?.availablePackages[0];
+    if (pkg) {
+      await Purchases.purchasePackage(pkg);
+    }
+  } catch (e) {
+    console.warn('Purchase failed', e);
+  }
+}


### PR DESCRIPTION
## Summary
- integrate RevenueCat for subscriptions
- gate CRM sync, notes, and analytics behind Pro/Team paywall
- prompt users to upgrade when hitting restricted features

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689022fa1e5c8330b8e20847656112a6