### PR TITLE
feat: protect main routes

### DIFF
--- a/app/main/_layout.tsx
+++ b/app/main/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack, router } from 'expo-router';
+import { auth } from '@/firebase';
+import { useEffect } from 'react';
+
+export default function MainLayout() {
+  useEffect(() => {
+    if (!auth.currentUser) {
+      router.replace('/auth/login');
+    }
+  }, []);
+
+  if (!auth.currentUser) {
+    return null;
+  }
+
+  return <Stack />;
+}


### PR DESCRIPTION
## Summary
- add authentication guard for main routes

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689022cb24b08330a0b956bed9a4c449