### PR TITLE
Add LinkedIn and photo fields to business card

### DIFF
--- a/app/main/edit.tsx
+++ b/app/main/edit.tsx
@@ -6,7 +6,9 @@ import {
   Button,
   StyleSheet,
   Alert,
+  Image,
 } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { auth, db } from '@/firebase';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 
@@ -17,6 +19,8 @@ interface CardData {
   phone: string;
   email: string;
   website: string;
+  linkedin: string;
+  photoUrl: string;
 }
 
 // Simple helpers for validating email and phone numbers
@@ -31,6 +35,8 @@ export default function EditCardScreen() {
     phone: '',
     email: '',
     website: '',
+    linkedin: '',
+    photoUrl: '',
   });
   const [loading, setLoading] = useState(false);
 
@@ -53,6 +59,8 @@ export default function EditCardScreen() {
             phone: data.phone ?? '',
             email: data.email ?? '',
             website: data.website ?? '',
+            linkedin: data.linkedin ?? '',
+            photoUrl: data.photoUrl ?? '',
           });
         }
       } catch (err) {
@@ -69,6 +77,21 @@ export default function EditCardScreen() {
     setCardData((prev) => ({ ...prev, [field]: value }));
   };
 
+  const handleImagePick = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission required', 'Permission to access photos is needed.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      setCardData((prev) => ({ ...prev, photoUrl: result.assets[0].uri }));
+    }
+  };
+
   const handleSave = async () => {
     if (!user) return;
     // Trim values to remove leading/trailing whitespace
@@ -79,6 +102,8 @@ export default function EditCardScreen() {
       phone: cardData.phone.trim(),
       email: cardData.email.trim(),
       website: cardData.website.trim(),
+      linkedin: cardData.linkedin.trim(),
+      photoUrl: cardData.photoUrl.trim(),
     };
     // Validate required fields
     if (!trimmed.fullName) {
@@ -148,6 +173,17 @@ export default function EditCardScreen() {
         onChangeText={(v) => handleChange('website', v)}
         autoCapitalize="none"
       />
+      <TextInput
+        style={styles.input}
+        placeholder="LinkedIn"
+        value={cardData.linkedin}
+        onChangeText={(v) => handleChange('linkedin', v)}
+        autoCapitalize="none"
+      />
+      {cardData.photoUrl ? (
+        <Image source={{ uri: cardData.photoUrl }} style={styles.photo} />
+      ) : null}
+      <Button title="Select Photo" onPress={handleImagePick} />
       <Button
         title={loading ? 'Saving…' : 'Save Card'}
         onPress={handleSave}
@@ -172,6 +208,13 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
     padding: 12,
     borderRadius: 6,
+    marginBottom: 8,
+  },
+  photo: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    alignSelf: 'center',
     marginBottom: 8,
   },
 });

--- a/app/main/share/[id].tsx
+++ b/app/main/share/[id].tsx
@@ -4,6 +4,7 @@ import {
   Text,
   ActivityIndicator,
   StyleSheet,
+  Image,
 } from 'react-native';
 import { useLocalSearchParams, Stack } from 'expo-router';
 import { doc, getDoc } from 'firebase/firestore';
@@ -16,6 +17,8 @@ interface CardData {
   phone: string;
   email: string;
   website: string;
+  linkedin: string;
+  photoUrl: string;
 }
 
 export default function SharedCardScreen() {
@@ -59,6 +62,9 @@ export default function SharedCardScreen() {
         </View>
       ) : (
         <View style={styles.container}>
+          {cardData.photoUrl && (
+            <Image source={{ uri: cardData.photoUrl }} style={styles.photo} />
+          )}
           <Text style={styles.name}>{cardData.fullName}</Text>
           {cardData.title && cardData.company && (
             <Text style={styles.field}>{cardData.title} at {cardData.company}</Text>
@@ -66,6 +72,7 @@ export default function SharedCardScreen() {
           {cardData.phone && <Text style={styles.field}>📞 {cardData.phone}</Text>}
           {cardData.email && <Text style={styles.field}>✉️ {cardData.email}</Text>}
           {cardData.website && <Text style={styles.field}>🌐 {cardData.website}</Text>}
+          {cardData.linkedin && <Text style={styles.field}>🔗 {cardData.linkedin}</Text>}
         </View>
       )}
     </>
@@ -92,5 +99,12 @@ const styles = StyleSheet.create({
   field: {
     fontSize: 16,
     marginBottom: 6,
+  },
+  photo: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    alignSelf: 'center',
+    marginBottom: 12,
   },
 });

--- a/app/main/share/card.tsx
+++ b/app/main/share/card.tsx
@@ -5,6 +5,7 @@ import {
   ActivityIndicator,
   Button,
   StyleSheet,
+  Image,
 } from 'react-native';
 import { useNavigation } from 'expo-router';
 import { doc, getDoc } from 'firebase/firestore';
@@ -17,6 +18,8 @@ interface CardData {
   phone: string;
   email: string;
   website: string;
+  linkedin: string;
+  photoUrl: string;
 }
 
 export default function CardScreen() {
@@ -62,6 +65,9 @@ export default function CardScreen() {
 
   return (
     <View style={styles.container}>
+      {cardData.photoUrl && (
+        <Image source={{ uri: cardData.photoUrl }} style={styles.photo} />
+      )}
       <Text style={styles.name}>{cardData.fullName}</Text>
       {cardData.title && cardData.company && (
         <Text style={styles.field}>{cardData.title} at {cardData.company}</Text>
@@ -69,6 +75,7 @@ export default function CardScreen() {
       {cardData.phone && <Text style={styles.field}>📞 {cardData.phone}</Text>}
       {cardData.email && <Text style={styles.field}>✉️ {cardData.email}</Text>}
       {cardData.website && <Text style={styles.field}>🌐 {cardData.website}</Text>}
+      {cardData.linkedin && <Text style={styles.field}>🔗 {cardData.linkedin}</Text>}
       <Button
         title="Edit Card"
         onPress={() => navigation.navigate('/main/edit')}
@@ -97,5 +104,12 @@ const styles = StyleSheet.create({
   field: {
     fontSize: 16,
     marginBottom: 6,
+  },
+  photo: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    alignSelf: 'center',
+    marginBottom: 12,
   },
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "expo": "~53.0.20",
+    "expo-image-picker": "^16.1.4",
     "expo-linking": "^7.1.7",
     "expo-router": "~5.1.4",
     "expo-status-bar": "~2.2.3",


### PR DESCRIPTION
## Summary
- add `linkedin` and `photoUrl` fields to card model
- allow picking a profile photo and entering LinkedIn in edit form
- render photo and LinkedIn on shared card views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689022def9d883309fad9498e7ed55f4